### PR TITLE
Adds merchant order show page

### DIFF
--- a/app/controllers/dashboard/orders_controller.rb
+++ b/app/controllers/dashboard/orders_controller.rb
@@ -1,0 +1,26 @@
+class Dashboard::OrdersController < ApplicationController
+
+  def show
+    @order = Order.find(params[:id])
+    @customer = User.find(@order.user_id)
+
+    # OrderItem.joins(:item).where('items.user_id = ?', current_user.id)
+
+    @my_order_items = OrderItem.joins(:item)\
+    .where('items.user_id = ?', current_user.id)\
+    .where('order_id = ?', @order.id)
+
+  end
+
+  # As a merchant
+  # When I visit an order show page from my dashboard
+  # I see the customer's name and address
+  # I only the items in the order that are being purchased from my inventory
+  # I do not see any items in the order being purchased from other merchants
+  # For each item, I see the following information:
+  # - the name of the item, which is a link to my item's show page
+  # - a small thumbnail of the item
+  # - my price for the item
+  # - the quantity the user wants to purchase
+
+end

--- a/app/controllers/dashboard/orders_controller.rb
+++ b/app/controllers/dashboard/orders_controller.rb
@@ -4,23 +4,9 @@ class Dashboard::OrdersController < ApplicationController
     @order = Order.find(params[:id])
     @customer = User.find(@order.user_id)
 
-    # OrderItem.joins(:item).where('items.user_id = ?', current_user.id)
-
     @my_order_items = OrderItem.joins(:item)\
     .where('items.user_id = ?', current_user.id)\
     .where('order_id = ?', @order.id)
 
   end
-
-  # As a merchant
-  # When I visit an order show page from my dashboard
-  # I see the customer's name and address
-  # I only the items in the order that are being purchased from my inventory
-  # I do not see any items in the order being purchased from other merchants
-  # For each item, I see the following information:
-  # - the name of the item, which is a link to my item's show page
-  # - a small thumbnail of the item
-  # - my price for the item
-  # - the quantity the user wants to purchase
-
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -4,4 +4,9 @@ class OrderItem < ApplicationRecord
 
 	validates_presence_of :quantity, :price
 
+	# instance methods
+	def item_name
+		item.name
+	end
+
 end

--- a/app/views/dashboard/items/edit-copy.html.erb
+++ b/app/views/dashboard/items/edit-copy.html.erb
@@ -1,0 +1,20 @@
+<%= form_for @item, url: edit_item_path(@item.id), method: :patch do |f| %>
+
+<%= f.label :name %>
+<%= f.text_field :name, required: true %>
+
+<%= f.label :description %>
+<%= f.text_area :description, required: true %>
+
+<%= f.label :image %>
+<%= f.text_field :image, value: "" %>
+
+<%= f.label :price %>
+<%= f.number_field :price, step: :any, required: true, min: 0.01 %>
+
+<%= f.label :inventory, "Available Inventory" %>
+<%= f.number_field :inventory, required: true, min: 0 %>
+
+<%= f.submit "Update Item" %>
+
+<% end %>

--- a/app/views/dashboard/orders/show.html.erb
+++ b/app/views/dashboard/orders/show.html.erb
@@ -1,0 +1,14 @@
+<h1>Order ID: <%= @order.id %></h1>
+<h3>Customer: <%= @customer.name %> </h3>
+<p>Address: <%= @customer.address %> </p>
+
+<% @my_order_items.each do |order_item| %>
+  <p>Item: <%= order_item.item_name %></p>
+  <p>Price: <%= order_item.price %></p>
+  <p>Order Quantity: <%= order_item.quantity %></p>
+
+  <div class="order-show-page-image">
+    <img class="thumbnail-image" src="<%= order_item.item.image %>"/>
+  </div>
+
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
 	namespace :dashboard do
 		resources :items, only: [:index, :new, :create, :edit]
+    resources :orders, only: :show
   end
 
   get '/dashboard', to: 'merchants#dashboard', as: 'dashboard'

--- a/spec/features/merchants/orders/show_spec.rb
+++ b/spec/features/merchants/orders/show_spec.rb
@@ -20,7 +20,6 @@ describe "As a merchant" do
 
       @order_1 = @buyer_1.orders.create(status: 0)
       @order_2 = @buyer_2.orders.create(status: 0)
-      # @order_3 = @buyer_3.orders.create(status: 0)
 
       @order_item_1_1 = @item_1.order_items.create!(item: @item_1, order: @order_1, quantity: 11, price: 1.00, fulfilled: false)
       @order_item_1_2 = @item_2.order_items.create!(item: @item_2, order: @order_1, quantity: 22, price: 2.00, fulfilled: false)
@@ -28,10 +27,7 @@ describe "As a merchant" do
 
       @order_item_2_3 = @item_3.order_items.create!(item: @item_3, order: @order_2, quantity: 2, price: 3.00, fulfilled: false)
       @order_item_2_4 = @item_4.order_items.create!(item: @item_4, order: @order_2, quantity: 2, price: 4.00, fulfilled: false)
-      #
-      # @order_item_3_5 = @item_5.order_items.create!(item: @item_5, order: @order_3, quantity: 3, price: 5.00, fulfilled: false)
-      # @order_item_3_6 = @item_6.order_items.create!(item: @item_6, order: @order_3, quantity: 3, price: 6.00, fulfilled: false)
-
+      
     end
 
     it "routes to the correct path" do

--- a/spec/features/merchants/orders/show_spec.rb
+++ b/spec/features/merchants/orders/show_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe "As a merchant" do
+  describe "when I visit an order show page from my dashboard" do
+    before :each do
+      @merchant_1 = User.create!(email: "merchant_1@email.com", password: "password", role: "merchant", name: "Murr Chante Sr", address: "123 Sesame St", city: "Merchantsville",   state: "MV", zip: 38511)
+			@merchant_2 =  User.create!(email: "merchant_2@email.com", password: "password", role: "merchant", name: "Mrs Chante",     address: "123 Sesame St", city: "New Merchantston", state: "MV", zip: 38511)
+
+			@buyer_1 = User.create!(email: "buyer_1@email.com", 	password: "password", role: "default",  name: "buyer_name_1", address: "1000 Abc Street", city: "City_1", state: "AA", zip: 00001)
+			@buyer_2 = User.create!(email: "buyer_2@email.com", 	password: "password", role: "default",  name: "buyer_name_2", address: "2000 Abc Street", city: "City_1", state: "AB", zip: 00002)
+			@buyer_3 = User.create!(email: "buyer_3@email.com", 	password: "password", role: "default",  name: "buyer_name_3", address: "3000 Abc Street", city: "City_1", state: "AB", zip: 00003)
+
+      @item_1 = @merchant_1.items.create!(name: "Item One",   active: true,  price: 1.11, description: "This is item one", 	 image: "https://picsum.photos/200/300?image=1", inventory: 100)
+      @item_3 = @merchant_1.items.create!(name: "Item Tres",  active: true,  price: 3.33, description: "This is item tres",  image: "https://picsum.photos/200/300?image=1", inventory: 300)
+      @item_5 = @merchant_1.items.create!(name: "Item Five", 	active: true,  price: 5.55, description: "This is item five",  image: "https://picsum.photos/200/300?image=1", inventory: 500)
+
+			@item_2 = @merchant_2.items.create!(name: "Item Two", 	active: true,  price: 2.00, description: "This is item two", 	 image: "https://picsum.photos/200/300?image=1", inventory: 200)
+			@item_4 = @merchant_2.items.create!(name: "Item Four", 	active: true,  price: 4.00, description: "This is item four",  image: "https://picsum.photos/200/300?image=1", inventory: 400)
+      @item_6 = @merchant_2.items.create!(name: "Item Six", 	active: true,  price: 6.00, description: "This is item six", 	 image: "https://picsum.photos/200/300?image=1", inventory: 600)
+
+      @order_1 = @buyer_1.orders.create(status: 0)
+      @order_2 = @buyer_2.orders.create(status: 0)
+      # @order_3 = @buyer_3.orders.create(status: 0)
+
+      @order_item_1_1 = @item_1.order_items.create!(item: @item_1, order: @order_1, quantity: 11, price: 1.00, fulfilled: false)
+      @order_item_1_2 = @item_2.order_items.create!(item: @item_2, order: @order_1, quantity: 22, price: 2.00, fulfilled: false)
+      @order_item_1_3 = @item_3.order_items.create!(item: @item_3, order: @order_1, quantity: 33, price: 3.00, fulfilled: false)
+
+      @order_item_2_3 = @item_3.order_items.create!(item: @item_3, order: @order_2, quantity: 2, price: 3.00, fulfilled: false)
+      @order_item_2_4 = @item_4.order_items.create!(item: @item_4, order: @order_2, quantity: 2, price: 4.00, fulfilled: false)
+      #
+      # @order_item_3_5 = @item_5.order_items.create!(item: @item_5, order: @order_3, quantity: 3, price: 5.00, fulfilled: false)
+      # @order_item_3_6 = @item_6.order_items.create!(item: @item_6, order: @order_3, quantity: 3, price: 6.00, fulfilled: false)
+
+    end
+
+    it "routes to the correct path" do
+
+      visit login_path
+
+      fill_in "Email", with:  "merchant_1@email.com"
+      fill_in "Password", with: "password"
+      click_button("Login")
+
+      visit dashboard_order_path(@order_1.id)
+
+      expect(page).to have_content(@buyer_1.name)
+      expect(page).to have_content(@buyer_1.address)
+
+      expect(page).to have_content(@item_1.name)
+      expect(page).to have_content(@order_item_1_1.price)
+      expect(page).to have_content(@order_item_1_1.quantity)
+      
+      expect(page).to have_content(@item_3.name)
+      expect(page).to have_content(@order_item_1_3.price)
+      expect(page).to have_content(@order_item_1_3.quantity)
+
+    end
+  end
+end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -4,4 +4,22 @@ RSpec.describe OrderItem, type: :model do
 	describe 'relationships' do
 		it {should belong_to :item}
 	end
+
+
+	describe "instance methods" do
+
+		it "#item_name" do
+			@merchant_1 =  User.create!(email: "merchant_2@email.com", password: "password", role: "merchant", name: "Mrs Chante",     address: "123 Sesame St", city: "New Merchantston", state: "MV", zip: 38511)
+
+			@buyer_1 = User.create!(email: "buyer_1@email.com", 	password: "password", role: "default",  name: "buyer_name_1", address: "1000 Abc Street", city: "City_1", state: "AA", zip: 00001)
+
+			@item_1 = @merchant_1.items.create!(name: "Item One",   active: true,  price: 1.11, description: "This is item one", 	 image: "https://picsum.photos/200/300?image=1", inventory: 100)
+
+			@order_1 = @buyer_1.orders.create(status: 0)
+
+			@order_item_1_1 = @item_1.order_items.create!(item: @item_1, order: @order_1, quantity: 11, price: 1.00, fulfilled: false)
+
+			expect(@order_item_1_1.item_name).to eq(@item_1.name)
+		end
+	end
 end


### PR DESCRIPTION
What does this PR do?

This pull request adds the merchant order show page which routes from the merchant dashboard. On the show page the customer name and address is shown along with only the items that the merchant is selling (i.e. items in the order sold by other merchants are not shown).

All tests passing and maintains 100% model coverage.