### PR TITLE
Story 6 unauthorized paths 404

### DIFF
--- a/app/controllers/admin/admins_controller.rb
+++ b/app/controllers/admin/admins_controller.rb
@@ -1,4 +1,4 @@
-class Admin::AdminsController < ActionController::Base
+class Admin::AdminsController < Admin::BaseController
 
   def dashboard
     @orders = Order.status_sorted

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,7 @@
+class Admin::BaseController < ApplicationController
+  before_action :require_admin
+
+  def require_admin
+    render file: "/public/404", status: 404 unless current_admin?
+  end
+end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,4 +1,4 @@
-class Admin::MerchantsController < ApplicationController
+class Admin::MerchantsController < Admin::BaseController
 	def index
 			@all_merchants = User.all_merchants
 	end
@@ -9,9 +9,9 @@ class Admin::MerchantsController < ApplicationController
 			if @merchant.role == "default"
 				redirect_to admin_user_path(@merchant)
 			end
-		else 
+		else
 			@merchant = User.find(params[:id])
-			redirect_to dashboard_path 
+			redirect_to dashboard_path
 		end
 	end
 
@@ -28,12 +28,12 @@ class Admin::MerchantsController < ApplicationController
 		flash[:enabled] = "#{@merchant.name} is now disabled"
 		redirect_to admin_merchants_path
 	end
-	
+
 	def downgrade
 		downgraded_merchant = User.find(params[:id])
 		downgraded_merchant.item_disable
 		downgraded_merchant.downgrade_to_user
 		flash[:downgraded] = "#{downgraded_merchant.name} has been downgraded to a regular user"
 		redirect_to admin_user_path(downgraded_merchant)
-	end	
+	end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,4 @@
-class Admin::UsersController < ApplicationController
+class Admin::UsersController < Admin::BaseController
 		def index
 			@all_reg_users = User.all_reg_users
 		end
@@ -13,7 +13,7 @@ class Admin::UsersController < ApplicationController
 				return not_found
 			end
 		end
-		
+
 		def upgrade
 			if current_admin?
 					user = User.find(params[:id])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,14 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
 
-  helper_method :current_user, :cart, :logged_in?, :current_admin?
+  helper_method :current_user,
+                :cart,
+                :logged_in?,
+                :current_admin?,
+                :current_visitor?,
+                :current_default?,
+                :current_merchant?
+
 
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
@@ -10,6 +17,18 @@ class ApplicationController < ActionController::Base
 
 	def current_admin?
 		!current_user.nil? && current_user.admin?
+	end
+
+	def current_visitor?
+		current_user.nil?
+	end
+
+	def current_default?
+		!current_user.nil? && current_user.default?
+	end
+
+	def current_merchant?
+		!current_user.nil? && current_user.merchant?
 	end
 
   def logout

--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -1,4 +1,10 @@
 class CartController < ApplicationController
+  before_action :require_visitor_or_default
+
+  def require_visitor_or_default
+    render file: "/public/404", status: 404 unless current_user == nil || current_user.default?
+  end
+
 
   def show
     @items_in_cart = cart.contents
@@ -29,7 +35,7 @@ class CartController < ApplicationController
     session[:cart] = session[:cart].reject{ |item_id, quantity| quantity <= 0 }
     redirect_to cart_path
   end
-	
+
 	def check_out
 		order = current_user.orders.create
 		cart.contents.each do |id, quant|

--- a/app/controllers/dashboard/base_controller.rb
+++ b/app/controllers/dashboard/base_controller.rb
@@ -1,0 +1,7 @@
+class Dashboard::BaseController < ApplicationController
+  before_action :require_admin
+
+  def require_admin
+    render file: "/public/404", status: 404 unless current_user.role == 1
+  end
+end

--- a/app/controllers/dashboard/base_controller.rb
+++ b/app/controllers/dashboard/base_controller.rb
@@ -2,6 +2,6 @@ class Dashboard::BaseController < ApplicationController
   before_action :require_admin
 
   def require_admin
-    render file: "/public/404", status: 404 unless current_user.role == 1
+    render file: "/public/404", status: 404 unless current_merchant?
   end
 end

--- a/app/controllers/dashboard/items_controller.rb
+++ b/app/controllers/dashboard/items_controller.rb
@@ -1,4 +1,4 @@
-class Dashboard::ItemsController < ApplicationController
+class Dashboard::ItemsController < Dashboard::BaseController
 
 	def index
 	end
@@ -10,5 +10,5 @@ class Dashboard::ItemsController < ApplicationController
 	def edit
 		@item = Item.find(params[:id])
 	end
-	
+
 end

--- a/app/controllers/dashboard/orders_controller.rb
+++ b/app/controllers/dashboard/orders_controller.rb
@@ -1,4 +1,4 @@
-class Dashboard::OrdersController < ApplicationController
+class Dashboard::OrdersController < Dashboard::BaseController
 
   def show
     @order = Order.find(params[:id])

--- a/app/controllers/merchant/dashboard_controller.rb
+++ b/app/controllers/merchant/dashboard_controller.rb
@@ -1,6 +1,0 @@
-class Dashboard::ItemsController < ApplicationController
-
-  def index
-  end
-
-end

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -4,6 +4,8 @@ class MerchantsController < ApplicationController
   end
 
   def dashboard
+    render file: "/public/404", status: 404 unless current_merchant?
+
 		@merchant = User.find(current_user.id)
     flash[:logged_in]            = "#{@merchant.name}, you're already logged in!"
     @orders                      = Order.all

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,6 +26,10 @@ class UsersController < ApplicationController
   end
 
   def profile
+    if current_user != nil
+      render file: "/public/404", status: 404 unless current_user.default?
+    end
+
     if params[:new_id] != nil
       @user = User.find(params[:new_id])
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,15 +26,15 @@ class UsersController < ApplicationController
   end
 
   def profile
-    if current_user != nil
-      render file: "/public/404", status: 404 unless current_user.default?
-    end
+    render file: "/public/404", status: 404 unless current_default?
 
     if params[:new_id] != nil
       @user = User.find(params[:new_id])
     else
-      @user = User.find(current_user.id)
-      flash[:logged_in] = "#{@user.name}, you're already logged in!"
+      if current_user != nil
+        @user = User.find(current_user.id)
+        flash[:logged_in] = "#{@user.name}, you're already logged in!"
+      end
     end
   end
 

--- a/spec/features/admin/admin_downgrades_merchant_to_user_spec.rb
+++ b/spec/features/admin/admin_downgrades_merchant_to_user_spec.rb
@@ -15,9 +15,8 @@ RSpec.describe 'as an admin on a merchant show page' do
   	  fill_in "Password", with: @merchant.password
   	  click_button("Login")
 			visit admin_merchant_path(@merchant)
-			expect(current_path).to eq(dashboard_path)
+			expect(page).to have_content("The page you were looking for doesn't exist.")
 			expect(page).to_not have_link("Downgrade to User")
-			visit logout_path
 		end
 
 		it 'downgrades, displays a flash message, and redirects when clicked' do
@@ -31,7 +30,7 @@ RSpec.describe 'as an admin on a merchant show page' do
 			expect(current_path).to eq(admin_user_path(@merchant))
 		end
 
-		it 'no longer allows the user to log in as a merchant and disables their items' do 
+		it 'no longer allows the user to log in as a merchant and disables their items' do
 			visit login_path
   	  fill_in "Email", with: @admin.email
   	  fill_in "Password", with: @admin.password

--- a/spec/features/navigation/admin_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/admin_cannot_navigate_to_certain_paths_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+describe "User visits unauthorized paths" do
+  context "as admin" do
+    it "does not allow admins to navigate to any /profile path" do
+      admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
+      #
+      # visit profile_path
+      # expect(page.status_code).to eq(404)
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      # visit profile_orders_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit profile_edit_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit order_show_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+    end
+
+    it "does not allow admins to navigate to any /dashboard path" do
+      admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
+
+      visit dashboard_items_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit new_dashboard_item_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      # visit dashboard_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+    end
+
+    it "does not allow admins to navigate to any /cart path" do
+      admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
+
+      # visit cart_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+    end
+  end
+end

--- a/spec/features/navigation/admin_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/admin_cannot_navigate_to_certain_paths_spec.rb
@@ -12,17 +12,17 @@ describe "User visits unauthorized paths" do
     end
 
     it "does not allow admins to navigate to any /dashboard path" do
-      # admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-      # allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
-      #
-      # visit dashboard_items_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit new_dashboard_item_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
 
-      # visit dashboard_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      visit dashboard_items_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit new_dashboard_item_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit dashboard_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
     end
 
     it "does not allow admins to navigate to any /cart path" do

--- a/spec/features/navigation/admin_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/admin_cannot_navigate_to_certain_paths_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe "User visits unauthorized paths" do
   context "as admin" do
     it "does not allow admins to navigate to any /profile path" do
-      admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
+      # admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      # allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
       #
       # visit profile_path
       # expect(page.status_code).to eq(404)
@@ -21,22 +21,22 @@ describe "User visits unauthorized paths" do
     end
 
     it "does not allow admins to navigate to any /dashboard path" do
-      admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
-
-      visit dashboard_items_path
-      expect(page).to have_content("The page you were looking for doesn't exist.")
-
-      visit new_dashboard_item_path
-      expect(page).to have_content("The page you were looking for doesn't exist.")
+      # admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      # allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
+      #
+      # visit dashboard_items_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit new_dashboard_item_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
 
       # visit dashboard_path
       # expect(page).to have_content("The page you were looking for doesn't exist.")
     end
 
     it "does not allow admins to navigate to any /cart path" do
-      admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
+      # admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      # allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
 
       # visit cart_path
       # expect(page).to have_content("The page you were looking for doesn't exist.")

--- a/spec/features/navigation/admin_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/admin_cannot_navigate_to_certain_paths_spec.rb
@@ -3,21 +3,12 @@ require "rails_helper"
 describe "User visits unauthorized paths" do
   context "as admin" do
     it "does not allow admins to navigate to any /profile path" do
-      # admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-      # allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
-      #
-      # visit profile_path
-      # expect(page.status_code).to eq(404)
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
 
-      # visit profile_orders_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit profile_edit_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit order_show_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      visit profile_path
+      expect(page.status_code).to eq(404)
+      expect(page).to have_content("The page you were looking for doesn't exist.")
     end
 
     it "does not allow admins to navigate to any /dashboard path" do

--- a/spec/features/navigation/admin_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/admin_cannot_navigate_to_certain_paths_spec.rb
@@ -35,11 +35,11 @@ describe "User visits unauthorized paths" do
     end
 
     it "does not allow admins to navigate to any /cart path" do
-      # admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-      # allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
+      admin_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 2, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
 
-      # visit cart_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      visit cart_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
     end
   end
 end

--- a/spec/features/navigation/merchants_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/merchants_cannot_navigate_to_certain_paths_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe "User visits unauthorized paths" do
+  context "as merchant" do
+    it "does not allow merchants to navigate to any /profile path" do
+      merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+			allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
+
+      # visit profile_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit profile_orders_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit profile_edit_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit order_show_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+    end
+
+    it "does not allow merchants to navigate to any /admin path" do
+      merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+			allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
+
+      visit admin_dashboard_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit admin_users_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit admin_merchants_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+    end
+
+    it "does not allow merchants to navigate to any /cart path" do
+      merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+			allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
+
+      # visit cart_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+    end
+  end
+end

--- a/spec/features/navigation/merchants_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/merchants_cannot_navigate_to_certain_paths_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe "User visits unauthorized paths" do
   context "as merchant" do
     it "does not allow merchants to navigate to any /profile path" do
-      merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-			allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
+      # merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+			# allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
 
       # visit profile_path
       # expect(page).to have_content("The page you were looking for doesn't exist.")
@@ -20,22 +20,22 @@ describe "User visits unauthorized paths" do
     end
 
     it "does not allow merchants to navigate to any /admin path" do
-      merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-			allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
-
-      visit admin_dashboard_path
-      expect(page).to have_content("The page you were looking for doesn't exist.")
-
-      visit admin_users_path
-      expect(page).to have_content("The page you were looking for doesn't exist.")
-
-      visit admin_merchants_path
-      expect(page).to have_content("The page you were looking for doesn't exist.")
+      # merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+			# allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
+      #
+      # visit admin_dashboard_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit admin_users_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit admin_merchants_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
     end
 
     it "does not allow merchants to navigate to any /cart path" do
-      merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-			allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
+      # merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+			# allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
 
       # visit cart_path
       # expect(page).to have_content("The page you were looking for doesn't exist.")

--- a/spec/features/navigation/merchants_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/merchants_cannot_navigate_to_certain_paths_spec.rb
@@ -34,11 +34,11 @@ describe "User visits unauthorized paths" do
     end
 
     it "does not allow merchants to navigate to any /cart path" do
-      # merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-			# allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
+      merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+			allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
 
-      # visit cart_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      visit cart_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
     end
   end
 end

--- a/spec/features/navigation/merchants_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/merchants_cannot_navigate_to_certain_paths_spec.rb
@@ -20,17 +20,17 @@ describe "User visits unauthorized paths" do
     end
 
     it "does not allow merchants to navigate to any /admin path" do
-      # merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-			# allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
-      #
-      # visit admin_dashboard_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit admin_users_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit admin_merchants_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+			allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
+
+      visit admin_dashboard_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit admin_users_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit admin_merchants_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
     end
 
     it "does not allow merchants to navigate to any /cart path" do

--- a/spec/features/navigation/merchants_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/merchants_cannot_navigate_to_certain_paths_spec.rb
@@ -3,20 +3,11 @@ require "rails_helper"
 describe "User visits unauthorized paths" do
   context "as merchant" do
     it "does not allow merchants to navigate to any /profile path" do
-      # merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-			# allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
+      merchant_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 1, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+			allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_1)
 
-      # visit profile_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit profile_orders_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit profile_edit_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit order_show_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      visit profile_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
     end
 
     it "does not allow merchants to navigate to any /admin path" do

--- a/spec/features/navigation/registered_user_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/registered_user_cannot_navigate_to_certain_paths_spec.rb
@@ -20,17 +20,17 @@ describe "Registered user visits unauthorized paths" do
     end
 
     it "does not allow registered users to navigate to any /admin path" do
-      # user_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 0, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-      # allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
-      #
-      # visit admin_dashboard_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit admin_users_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit admin_merchants_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      user_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 0, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+
+      visit admin_dashboard_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit admin_users_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit admin_merchants_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
     end
   end
 end

--- a/spec/features/navigation/registered_user_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/registered_user_cannot_navigate_to_certain_paths_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "Registered user visits unauthorized paths" do
+  context "as a registered user" do
+    it "does not allow registered users to navigate to any /dashboard path" do
+      user_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 0, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+
+      # visit dashboard_items_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit new_dashboard_item_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit dashboard_order_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit dashboard_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+    end
+
+    it "does not allow registered users to navigate to any /admin path" do
+      user_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 0, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+
+      visit admin_dashboard_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit admin_users_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit admin_merchants_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+    end
+  end
+end

--- a/spec/features/navigation/registered_user_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/registered_user_cannot_navigate_to_certain_paths_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe "Registered user visits unauthorized paths" do
   context "as a registered user" do
     it "does not allow registered users to navigate to any /dashboard path" do
-      user_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 0, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+      # user_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 0, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      # allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
 
       # visit dashboard_items_path
       # expect(page).to have_content("The page you were looking for doesn't exist.")
@@ -20,17 +20,17 @@ describe "Registered user visits unauthorized paths" do
     end
 
     it "does not allow registered users to navigate to any /admin path" do
-      user_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 0, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
-
-      visit admin_dashboard_path
-      expect(page).to have_content("The page you were looking for doesn't exist.")
-
-      visit admin_users_path
-      expect(page).to have_content("The page you were looking for doesn't exist.")
-
-      visit admin_merchants_path
-      expect(page).to have_content("The page you were looking for doesn't exist.")
+      # user_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 0, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      # allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+      #
+      # visit admin_dashboard_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit admin_users_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit admin_merchants_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
     end
   end
 end

--- a/spec/features/navigation/registered_user_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/registered_user_cannot_navigate_to_certain_paths_spec.rb
@@ -3,20 +3,17 @@ require "rails_helper"
 describe "Registered user visits unauthorized paths" do
   context "as a registered user" do
     it "does not allow registered users to navigate to any /dashboard path" do
-      # user_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 0, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
-      # allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+      user_1 = User.create!(email: "Bob@bob.bob", password: "password", role: 0, active: true, name: "Bob Bob", address: "123 Shady Lane", city: "Boulda", state: "CO", zip: "80303")
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
 
-      # visit dashboard_items_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit new_dashboard_item_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit dashboard_order_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit dashboard_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      visit dashboard_items_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit new_dashboard_item_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit dashboard_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
     end
 
     it "does not allow registered users to navigate to any /admin path" do

--- a/spec/features/navigation/visitors_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/visitors_cannot_navigate_to_certain_paths_spec.rb
@@ -3,17 +3,11 @@ require "rails_helper"
 describe "Visitor visits unauthorized paths" do
   context "as a visitor" do
     it "does not allow visitors to navigate to any /dashboard path" do
-      # visit dashboard_items_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit new_dashboard_item_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit dashboard_order_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit dashboard_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      visit dashboard_items_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit new_dashboard_item_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
     end
 
     it "does not allow visitors to navigate to any /admin path" do
@@ -28,17 +22,11 @@ describe "Visitor visits unauthorized paths" do
     end
 
     it "does not allow visitors to navigate to any /profile path" do
-      # visit profile_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit profile_orders_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit profile_edit_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit order_show_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      visit profile_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit profile_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
     end
   end
 end

--- a/spec/features/navigation/visitors_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/visitors_cannot_navigate_to_certain_paths_spec.rb
@@ -17,14 +17,14 @@ describe "Visitor visits unauthorized paths" do
     end
 
     it "does not allow visitors to navigate to any /admin path" do
-      visit admin_dashboard_path
-      expect(page).to have_content("The page you were looking for doesn't exist.")
-
-      visit admin_users_path
-      expect(page).to have_content("The page you were looking for doesn't exist.")
-
-      visit admin_merchants_path
-      expect(page).to have_content("The page you were looking for doesn't exist.")
+      # visit admin_dashboard_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit admin_users_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit admin_merchants_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
     end
 
     it "does not allow visitors to navigate to any /profile path" do

--- a/spec/features/navigation/visitors_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/visitors_cannot_navigate_to_certain_paths_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe "Visitor visits unauthorized paths" do
+  context "as a visitor" do
+    it "does not allow visitors to navigate to any /dashboard path" do
+      # visit dashboard_items_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit new_dashboard_item_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit dashboard_order_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit dashboard_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+    end
+
+    it "does not allow visitors to navigate to any /admin path" do
+      visit admin_dashboard_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit admin_users_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit admin_merchants_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+    end
+
+    it "does not allow visitors to navigate to any /profile path" do
+      # visit profile_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit profile_orders_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit profile_edit_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      #
+      # visit order_show_path
+      # expect(page).to have_content("The page you were looking for doesn't exist.")
+    end
+  end
+end

--- a/spec/features/navigation/visitors_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/navigation/visitors_cannot_navigate_to_certain_paths_spec.rb
@@ -17,14 +17,14 @@ describe "Visitor visits unauthorized paths" do
     end
 
     it "does not allow visitors to navigate to any /admin path" do
-      # visit admin_dashboard_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit admin_users_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
-      #
-      # visit admin_merchants_path
-      # expect(page).to have_content("The page you were looking for doesn't exist.")
+      visit admin_dashboard_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit admin_users_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit admin_merchants_path
+      expect(page).to have_content("The page you were looking for doesn't exist.")
     end
 
     it "does not allow visitors to navigate to any /profile path" do


### PR DESCRIPTION
What does this PR do?
--
This PR satisfies story 6 and adds 404 error messages for the following:
* If visitors try to navigate to any /profile path
* If visitors try to navigate to any /dashboard path
* If visitors try to navigate to any /admin path
* If registered users try to navigate to any /dashboard path
* If registered users try to navigate to any /admin path
* If merchants try to navigate to any /profile path
* If merchants try to navigate to any /admin path
* If merchants try to navigate to any /cart path
* If admin users try to navigate to any /profile path
* If admin users try to navigate to any /dashboard path
* If admin users try to navigate to any /cart path